### PR TITLE
feat: initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ this behavior is acceptable as long as the restarts don't happen too often.
 
 ```
 curl 'https://spark-group-oracle.fly.io/'
-{"group": "SoMeId", "sig": "ECDSA signature" }
+{"group": "SoMeId", "sig": "9FvjLX8J5ujXKmpaHImW7446OOaTR3w1rCJN3YO9mCXe1/s4FFlLVJkqF216BMdQezs/owFNgM3ivWMNZZFnAA==" }
 ```
 
 How to validate the signature JavaScript:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
 # group-oracle
+
 An oracle mapping IPv4 /24 subnet into a group id
+
+## Why?
+
+In [SPARK](https://github.com/filecoin-station/spark), we want to use IPv4 as a scarce resource.
+However, IP addresses are considered as a personal information. Extra considerations are required
+to implement a collection process that's compliant with GDPR & CCPA.
+
+Furthermore, SPARK measurements are recorded in IPFS & on chain and publicly available, which
+amplifies the privacy problems.
+
+At the same time, the SPARK protocol does not need to know the actual IPv4 /24 subnet. All we need
+is a mapping function `oracle(ip_addres) -> group_id` that meets the following requirements:
+
+- For the duration of a single SPARK round, the service returns:
+  1. the same `group_id` value for all IPv4 addresses in the same /24 subnet
+  2. different `group_id` values for IPv4 addresses in different /24 subnets
+
+- The service does not collect IPv4 address (in logs, persistent storage, etc.)
+
+The first requirement is "soft". If the service restarts during a SPARK round and then starts
+issuing different group ids to the same subnets compared to group ids issues before the restart,
+this behavior is acceptable as long as the restarts don't happen too often.
+
+## Basic use
+
+```
+curl 'https://spark-group-oracle.fly.io/'
+{"group": "SoMeId", "sig": "ECDSA signature" }
+```
+
+How to validate the signature JavaScript:
+
+```js
+await crypto.subtle.verify(
+  'Ed25519',
+  publicKey,
+  // signature
+  Buffer.from(body.sig, 'base64'),
+  // payload signed
+  Buffer.from(body.group)
+)
+```
+
+## Development
+
+Start the API service:
+
+```bash
+PRIVATE_KEY=YourPrivateKey npm start
+```
+
+Run tests and linters:
+
+```bash
+npm test
+```
+
+## Managing identities
+
+Generate a new private & public key:
+
+```bash
+node bin/gen-keys.js
+```
+
+Use the private key to configure Fly.io secrets used for group-oracle deployment.
+
+Use the public key to configure Fly.io secrets used by spark-evaluate deployment.
+
+## Deployment
+
+Pushes to `main` will be deployed automatically.
+
+Perform manual devops using [Fly.io](https://fly.io):
+
+```bash
+$ fly deploy
+```

--- a/bin/gen-keys.js
+++ b/bin/gen-keys.js
@@ -1,0 +1,56 @@
+console.log('Generating a new key pair')
+
+const { privateKey, publicKey } = await crypto.subtle.generateKey(
+  'Ed25519',
+  true,
+  ['sign', 'verify']
+)
+
+const exportKeyForImport = async (key) => {
+  const data = JSON.stringify(
+    await crypto.subtle.exportKey('jwk', key)
+  )
+  const bytes = Buffer.from(data, 'utf-8')
+  return bytes.toString('base64')
+}
+
+const exportedPrivateKey = await exportKeyForImport(privateKey)
+const exportedPublicKey = await exportKeyForImport(publicKey)
+
+console.log('PRIVATE KEY\n%s', exportedPrivateKey)
+console.log('PUBLIC KEY\n%s', exportedPublicKey)
+
+// NOTE(bajtos) There is no need to run this code as part of our CI. I found it useful while
+// figuring out how to generate, export and import keys, and also how to sign & verify the payload.
+// I am keeping this code around for the future where we may want to change the algorithm used
+// for the signing identity.
+if (process.env.TEST) {
+  const assert = await import('node:assert')
+
+  const priv = await crypto.subtle.importKey(
+    'jwk',
+    JSON.parse(Buffer.from(exportedPrivateKey, 'base64').toString('utf-8')),
+    'Ed25519',
+    true,
+    ['sign']
+  )
+
+  const pub = await crypto.subtle.importKey(
+    'jwk',
+    JSON.parse(Buffer.from(exportedPublicKey, 'base64').toString('utf-8')),
+    'Ed25519',
+    true,
+    ['verify']
+  )
+
+  const payload = Buffer.from('hello world')
+  const sign1 = await crypto.subtle.sign('Ed25519', priv, payload)
+  const sign2 = await crypto.subtle.sign('Ed25519', privateKey, payload)
+  assert.strictEqual(
+    Buffer.from(sign1).toString('hex'),
+    Buffer.from(sign2).toString('hex')
+  )
+
+  assert.ok(await crypto.subtle.verify('Ed25519', publicKey, sign1, payload))
+  assert.ok(await crypto.subtle.verify('Ed25519', pub, sign2, payload))
+}

--- a/bin/oracle.js
+++ b/bin/oracle.js
@@ -1,0 +1,50 @@
+import http from 'node:http'
+import { once } from 'node:events'
+import { createHandler } from '../index.js'
+import Sentry from '@sentry/node'
+import fs from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const {
+  PORT = 8080,
+  HOST = '127.0.0.1',
+  PRIVATE_KEY,
+  SENTRY_ENVIRONMENT = 'development'
+} = process.env
+
+const pkg = JSON.parse(
+  await fs.readFile(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'package.json'
+    ),
+    'utf8'
+  )
+)
+
+Sentry.init({
+  dsn: 'https://bfdcbde3cbb19c7ca010b407cb9d7337@o1408530.ingest.sentry.io/4506058839162880',
+  release: pkg.version,
+  environment: SENTRY_ENVIRONMENT,
+  tracesSampleRate: 0.1
+})
+
+if (!PRIVATE_KEY) {
+  throw new Error('Env var PRIVATE_KEY is required')
+}
+
+const privateKey = await crypto.subtle.importKey(
+  'jwk',
+  JSON.parse(Buffer.from(PRIVATE_KEY, 'base64').toString('utf-8')),
+  'Ed25519',
+  true,
+  ['sign']
+)
+const handler = await createHandler({ privateKey, logger: console })
+const server = http.createServer(handler)
+console.log('Starting the http server on host %j port %s', HOST, PORT)
+server.listen(PORT, HOST)
+await once(server, 'listening')
+console.log(`http://${HOST}:${PORT}`)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+export { createHandler } from './lib/handler.js'

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,0 +1,46 @@
+import { json } from 'http-responders'
+import { mapRequestToInetGroup } from './inet-grouping.js'
+
+export const createHandler = async ({ privateKey, logger }) => {
+  return (req, res) => {
+    const start = new Date()
+    logger.info(`${req.method} ${req.url} ...`)
+    handler(req, res, privateKey, logger)
+      .catch(err => errorHandler(res, err, logger))
+      .then(() => {
+        logger.info(`${req.method} ${req.url} ${res.statusCode} (${new Date() - start}ms)`)
+      })
+  }
+}
+
+const handler = async (req, res, privateKey, logger) => {
+  if (req.url !== '/' || req.method !== 'GET') {
+    return notFound(res)
+  }
+
+  const group = mapRequestToInetGroup(req)
+  const sig = await crypto.subtle.sign('Ed25519', privateKey, Buffer.from(group))
+  json(res, {
+    group,
+    sig: Buffer.from(sig).toString('base64')
+  })
+}
+
+const errorHandler = (res, err, logger) => {
+  if (err instanceof SyntaxError) {
+    res.statusCode = 400
+    res.end('Invalid JSON Body')
+  } else if (err.statusCode) {
+    res.statusCode = err.statusCode
+    res.end(err.message)
+  } else {
+    logger.error(err)
+    res.statusCode = 500
+    res.end('Internal Server Error')
+  }
+}
+
+const notFound = (res) => {
+  res.statusCode = 404
+  res.end('Not Found')
+}

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -1,0 +1,27 @@
+// See https://stackoverflow.com/a/36760050/69868
+const IPV4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/
+
+export const mapRequestToInetGroup = (/** @type {import('node:http').IncomingMessage} */ req) => {
+  let addr = req.socket.remoteAddress
+
+  const flyClientAddr = req.headers['fly-client-ip']
+  if (flyClientAddr) addr = flyClientAddr
+
+  // Remote address can be undefined, see https://nodejs.org/api/net.html#socketremoteaddress
+  if (!addr) return undefined
+
+  if (addr.startsWith('::ffff:')) {
+    // Some operating systems are wrapping the IPv4 address into IPv6
+    // https://www.apnic.net/get-ip/faqs/what-is-an-ip-address/ipv6-address-types/
+    addr = addr.slice(7)
+  }
+
+  if (!IPV4_REGEX.test(addr)) {
+    return undefined
+  }
+
+  // Hide the last byte of the IPv4 address, change it to "0"
+  addr = addr.slice(0, addr.lastIndexOf('.')) + '.0'
+
+  return addr
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "raw-body": "^2.5.2"
       },
       "devDependencies": {
+        "debug": "^4.3.4",
+        "light-my-request": "^5.11.0",
         "mocha": "^10.2.0",
         "standard": "^17.1.0"
       }
@@ -2556,6 +2558,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/light-my-request": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.11.0.tgz",
+      "integrity": "sha512-qkFCeloXCOMpmEdZ/MV91P8AT4fjwFXWaAFz3lUeStM8RcoM1ks4J/F8r1b3r6y/H4u3ACEJ1T+Gv5bopj7oDA==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0",
+        "process-warning": "^2.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
@@ -3091,6 +3104,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==",
+      "dev": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3409,6 +3428,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+      "dev": true
     },
     "node_modules/set-function-name": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test": "standard && mocha"
   },
   "devDependencies": {
+    "debug": "^4.3.4",
+    "light-my-request": "^5.11.0",
     "mocha": "^10.2.0",
     "standard": "^17.1.0"
   },

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -1,0 +1,69 @@
+import http from 'node:http'
+import { once } from 'node:events'
+import assert, { AssertionError } from 'node:assert'
+import createDebug from 'debug'
+import { createHandler } from '../lib/handler.js'
+
+const debug = createDebug('test')
+
+const { privateKey, publicKey } = await crypto.subtle.generateKey(
+  'Ed25519',
+  true,
+  ['sign', 'verify']
+)
+
+describe('Oracle API handler', () => {
+  let baseUrl
+  let server
+
+  before(async () => {
+    const handler = await createHandler({
+      privateKey,
+      logger: {
+        info (...args) { debug(...args) },
+        error (...args) { console.error(...args) }
+      }
+    })
+    server = http.createServer(handler)
+    server.listen()
+    await once(server, 'listening')
+    baseUrl = `http://127.0.0.1:${server.address().port}`
+    server.unref()
+  })
+
+  after(async () => {
+    server.closeAllConnections()
+    server.close()
+  })
+
+  describe('GET /', () => {
+    it('returns a group id with signature', async () => {
+      const res = await fetch(baseUrl)
+      await assertResponseStatus(res, 200)
+      const body = await res.json()
+      assert.deepStrictEqual(Object.keys(body), ['group', 'sig'])
+
+      assert.ok(
+        await crypto.subtle.verify(
+          'Ed25519',
+          publicKey,
+          // signature
+          Buffer.from(body.sig, 'base64'),
+          // payload signed
+          Buffer.from(body.group)
+        ),
+        'signature match'
+      )
+    })
+  })
+})
+
+const assertResponseStatus = async (res, status) => {
+  if (res.status !== status) {
+    throw new AssertionError({
+      actual: res.status,
+      expected: status,
+      message: await res.text()
+    })
+  }
+}

--- a/test/inet-grouping.test.js
+++ b/test/inet-grouping.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert'
+import { mapRequestToInetGroup } from '../lib/inet-grouping.js'
+import { Request as FakeRequest } from 'light-my-request/lib/request.js'
+
+describe('mapRequestToInetGroup', () => {
+  it('maps IPv4 address to /24 subnet', () => {
+    const group = mapRequestToInetGroup(createRequestFromAddress('10.20.30.40'))
+    assert.strictEqual(group, '10.20.30.0')
+  })
+
+  it('maps IPv4-inside-IPv6 to IPv4 /24 subnet', () => {
+    const group = mapRequestToInetGroup(createRequestFromAddress('::ffff:127.0.0.1'))
+    assert.strictEqual(group, '127.0.0.0')
+  })
+
+  it('rejects IPv6 addresses', () => {
+    const group = mapRequestToInetGroup(createRequestFromAddress('bf27:c63a:689a:da7c:8150:6e23:1045:045d'))
+    assert.strictEqual(group, undefined)
+  })
+
+  it('parses `Fly-Client-IP` request header', () => {
+    const req = createRequestFromAddress('10.20.30.40', {
+      'Fly-Client-IP': '1.2.3.4'
+    })
+    const group = mapRequestToInetGroup(req)
+    assert.strictEqual(group, '1.2.3.0')
+  })
+
+  it('parses `fly-client-ip` request header', () => {
+    const req = createRequestFromAddress('10.20.30.40', {
+      'fly-client-ip': '1.2.3.4'
+    })
+    const group = mapRequestToInetGroup(req)
+    assert.strictEqual(group, '1.2.3.0')
+  })
+})
+
+const createRequestFromAddress = (remoteAddress, headers) => {
+  return new FakeRequest({
+    method: 'GET',
+    url: '/',
+    remoteAddress,
+    headers
+  })
+}


### PR DESCRIPTION
Todo:

- [x] HTTP API server
- [x] Extract IPv4 /24 subnet from the request, supporting 'fly-client-ip'
- [x] Sign the response
- [ ] Map IPv4 subnet to a randomized group id
- [ ] Disable response caching
- [ ] Add unique `nonce` to signature to prevent replay attacks

Later:
- Identify participants from U.S- or E.U.- sanctioned countries to implement geofencing
 
Links:
- https://github.com/filecoin-station/spark-api/pull/104
- https://github.com/filecoin-station/spark/issues/29
- https://github.com/filecoin-station/spark/issues/20
